### PR TITLE
Fix project structure docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ careerfm/
 ├── infrastructure/      # AWS CDK インフラコード
 │   ├── lib/
 │   │   └── stacks/     # CDKスタック定義
-│   └── bin/            # CDKアプリケーション
+│   ├── bin/            # CDKアプリケーション
+│   └── test/           # インフラ用テストコード
 ├── packages/
-│   ├── frontend/       # Next.js フロントエンド
-│   └── backend/        # Lambda関数
+│   └── frontend/       # Next.js フロントエンド
 ├── docs/               # ドキュメント
-├── tests/              # テストコード
+├── decisions/          # 意思決定記録
 └── scripts/            # ユーティリティスクリプト
 ```
 


### PR DESCRIPTION
## Summary
- update README project structure diagram to match repo layout
- clarify that infrastructure tests live in `infrastructure/test`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843be4c327083339d3e2fc618b09bef