### PR TITLE
Add API health endpoint test

### DIFF
--- a/infrastructure/jest.config.js
+++ b/infrastructure/jest.config.js
@@ -3,6 +3,6 @@ module.exports = {
   roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }]
   }
 };

--- a/infrastructure/test/infrastructure.test.ts
+++ b/infrastructure/test/infrastructure.test.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { AuthStack } from '../lib/stacks/auth-stack';
 import { StorageStack } from '../lib/stacks/storage-stack';
+import { ApiStack } from '../lib/stacks/api-stack';
 
 describe('Infrastructure Stacks', () => {
   test('AuthStack creates Cognito User Pool', () => {
@@ -35,6 +36,47 @@ describe('Infrastructure Stacks', () => {
     
     template.hasResourceProperties('AWS::DynamoDB::Table', {
       TableName: 'careerfm-audio-cards-test',
+    });
+  });
+
+  test('ApiStack creates HealthFunction and GET /health endpoint', () => {
+    const app = new cdk.App();
+
+    const auth = new AuthStack(app, 'MockAuthStack', {
+      env: { account: '123456789012', region: 'ap-northeast-1' },
+      stage: 'test',
+      projectName: 'careerfm',
+    });
+
+    const storage = new StorageStack(app, 'MockStorageStack', {
+      env: { account: '123456789012', region: 'ap-northeast-1' },
+      stage: 'test',
+      projectName: 'careerfm',
+    });
+
+    const stack = new ApiStack(app, 'TestApiStack', {
+      env: { account: '123456789012', region: 'ap-northeast-1' },
+      stage: 'test',
+      projectName: 'careerfm',
+      userPool: auth.userPool,
+      audioBucket: storage.audioBucket,
+      audioCardTable: storage.audioCardTable,
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Handler: 'index.handler',
+      Runtime: 'nodejs18.x',
+    });
+
+    const healthResourceId = template.getResourceId('AWS::ApiGateway::Resource', {
+      Properties: { PathPart: 'health' }
+    });
+
+    template.hasResourceProperties('AWS::ApiGateway::Method', {
+      HttpMethod: 'GET',
+      ResourceId: { Ref: healthResourceId },
     });
   });
 });

--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -23,7 +23,7 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "exclude": [
     "node_modules",

--- a/infrastructure/tsconfig.test.json
+++ b/infrastructure/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
## Summary
- extend infrastructure tests to check ApiStack health resources
- configure ts-jest with custom tsconfig to allow jest globals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843be4fbb34833386e7da91d81609cd